### PR TITLE
fix: 마커 지도에 바로 찍기, 게시글쓰고 클릭된마커 없애기

### DIFF
--- a/src/components/ExtendSideBar/PostForm/PostForm.js
+++ b/src/components/ExtendSideBar/PostForm/PostForm.js
@@ -189,6 +189,7 @@ export const PostForm = ({ closePost, openshow }) => {
       postMutate();
     }
   };
+  console.log(meetingPlace);
 
   return (
     <Styled.PostFormBlock>

--- a/src/hooks/api.js
+++ b/src/hooks/api.js
@@ -1,6 +1,8 @@
 import axios from "axios";
 
 export const getData = async position => {
+  console.log(position);
+
   const { lat, lng } = position;
   const address = await axios.get(`${process.env.REACT_APP_KAKAO_RESTFUL_URL}?x=${lng}&y=${lat}`, {
     headers: {

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -3,11 +3,12 @@ import { fetchData } from "api/contents";
 import plusbutton from "assets/pngs/post_plus.png";
 import { ClickedMarker, Header, MarkerItem, PostForm, Show, Sidebar, useDialog } from "components";
 import { useMount } from "hooks";
+import { getData } from "hooks/api";
 import { useState } from "react";
 import { Map } from "react-kakao-maps-sdk";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import { setCenter, setPlace } from "redux/modules/centerSlice";
+import { setCenter, setPlace, setPostion } from "redux/modules/centerSlice";
 import * as Styled from "./Home.styles";
 
 export const Home = () => {
@@ -28,9 +29,15 @@ export const Home = () => {
   const currentUrl = useLocation();
   const { isLoading, data } = useQuery(["marker"], fetchData);
 
-  const MapClickHandler = (_t, e) => {
+  const MapClickHandler = async (_t, e) => {
     setPosition({ lat: e.latLng.getLat(), lng: e.latLng.getLng() });
     setSelected(null);
+
+    if (showPost) {
+      const address = await getData({ lat: e.latLng.getLat(), lng: e.latLng.getLng() });
+      dispatch(setPlace(address));
+      dispatch(setPostion({ lat: e.latLng.getLat(), lng: e.latLng.getLng() }));
+    }
   };
 
   const openPost = () => {
@@ -70,6 +77,7 @@ export const Home = () => {
   };
 
   const closePost = () => {
+    setPosition({});
     setShowPost(false);
     navigate("/home");
   };
@@ -99,7 +107,7 @@ export const Home = () => {
               />
             );
           })}
-          <ClickedMarker closePost={closePost} openPost={openPost} position={position} />
+          <ClickedMarker openPost={openPost} position={position} />
         </Map>
         <Styled.PlusButton onClick={postButtonClick}>
           <img src={plusbutton} alt="게시물 등록" style={{ width: "80px" }} />


### PR DESCRIPTION
- 우하단 + 버튼 클릭하고 지도에 마커로 주소 입력시, 마커클릭>플러스버튼 클릭의 과정을 없애고 마커를 지도에 찍기만 해도 주소가 들어가도록 고침
- 게시물 작성 후 클릭해서 남아있는 마커 없앰